### PR TITLE
Skip the dependencies which aren't Installable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,7 +17,7 @@ else
     # If pipenv is present on the path, and we find a Pipfile without a Pipfile.lock, run pipenv update
     if [ -x "$(command -v pip)" ]; then
         if [ -f "requirements.txt" ]; then
-            pip install -r requirements.txt
+            cat requirements.txt | xargs -n 1 pip install # Skipping the dependencies which aren't Installable
         fi
         if [ -f "Pipfile" ]; then
             if ! [ -x "$(command -v pipenv)" ]; then


### PR DESCRIPTION
In case of dependencies are not found, Pip fails and don't install rest of dependencies so, tweaking installing command. 