### PR TITLE
Skip test when maven install

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,7 +36,7 @@ else
     # If mvn is present on the path, and we find a pom.xml, run mvn install
     if [ -x "$(command -v mvn)" ]; then
         if [ -f "pom.xml" ]; then
-            mvn install --no-transfer-progress
+            mvn install --no-transfer-progress -DskipTests
         fi
     fi
 


### PR DESCRIPTION
Maven test phase if before install. If a unit test breaks, the entire build breaks without performing a `snyk test`.
Solving issue #8. 