### PR TITLE
removed check for a file flag to generate sarif output

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -81,12 +81,7 @@ if [ "$INPUT_COMMAND" = "test" -a "$INPUT_JSON" = "true" ]; then
 fi
 
 if [ "$INPUT_COMMAND" = "test" -a "$INPUT_SARIF" = "true" ]; then
-    # SARIF output is only relevant if a file is specified as well
-    # The IaC Action uses a property, while will use a flag
-    args=$@
-    if [ "${args/--file}" != "$args" ] || ! [ -z "$INPUT_FILE" ] ; then
-        SARIF_OUTPUT="--sarif-file-output=snyk.sarif"
-    fi
+    SARIF_OUTPUT="--sarif-file-output=snyk.sarif"
 fi
 
 exec $@ $JSON_OUTPUT $SARIF_OUTPUT


### PR DESCRIPTION
The default behaviour of the Snyk IaC CLI has changed and you no longer have to specify a file. 

Previously you had to run the command as such
`$ snyk iac test deployment.yaml`
Now you can run
`$ snyk iac test` and the `deployment.yaml` file will be correctly picked up. 

This means the `file` property as defined in the Snyk IaC GitHub action no longer has to be specified
https://github.com/snyk/actions/blob/master/iac/action.yml#L13

The impact of this means that a user not providing the `file` property in their GitHub job definition, would not trigger the `.sarif` output because of this conditional logic. 

The expected behaviour is for the `.sarif` file to always be generated which this PR addresses. 

