### PR TITLE
Adds a SNYK VERSION at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG IMAGE
 ARG TAG
+ARG SNYKVERSION
 
 FROM ${IMAGE} as parent
 ENV MAVEN_CONFIG="" \
@@ -14,7 +15,7 @@ CMD ["snyk", "test"]
 
 FROM ubuntu as snyk
 RUN apt-get update && apt-get install -y curl wget
-RUN curl -s https://api.github.com/repos/snyk/snyk/releases/latest | grep "browser_download_url" | grep linux | cut -d '"' -f 4 | wget -i - && \
+RUN curl -s https://api.github.com/repos/snyk/snyk/releases/tags/${SNYKVERSION} | grep "browser_download_url" | grep linux | cut -d '"' -f 4 | wget -i - && \
     sha256sum -c snyk-linux.sha256 && \
     mv snyk-linux /usr/local/bin/snyk && \
     chmod +x /usr/local/bin/snyk
@@ -22,7 +23,7 @@ RUN curl -s https://api.github.com/repos/snyk/snyk/releases/latest | grep "brows
 
 FROM alpine as snyk-alpine
 RUN apk add --no-cache curl wget
-RUN curl -s https://api.github.com/repos/snyk/snyk/releases/latest | grep "browser_download_url" | grep alpine | cut -d '"' -f 4 | wget -i - && \
+RUN curl -s https://api.github.com/repos/snyk/snyk/releases/tags/${SNYKVERSION} | grep "browser_download_url" | grep alpine | cut -d '"' -f 4 | wget -i - && \
     sha256sum -c snyk-alpine.sha256 && \
     mv snyk-alpine /usr/local/bin/snyk && \
     chmod +x /usr/local/bin/snyk

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ ifndef DOCKER_BUILDKIT
 endif
 
 build-linux: check-buildkit
-	@awk '{ print "docker build --build-arg IMAGE="$$1" --build-arg TAG="$$NF" -t "$(PREFIX)":"$$NF" ." | "/bin/sh"}' $(NAME)
+	@awk '{ print "docker build --build-arg IMAGE="$$1" --build-arg TAG="$$NF" --build-arg SNYK_VERSION="$(SNYK_VERSION)" -t "$(PREFIX)":"$$NF"-"$(SNYK_VERSION)" ." | "/bin/sh"}' $(NAME)
 
 build-alpine: check-buildkit
-	@awk '{ print "docker build --target alpine --build-arg IMAGE="$$1" --build-arg TAG="$$NF" -t "$(PREFIX)":"$$NF" ." | "/bin/sh"}' $(NAME)
+	@awk '{ print "docker build --target alpine --build-arg IMAGE="$$1" --build-arg TAG="$$NF" --build-arg SNYK_VERSION="$(SNYK_VERSION)" -t "$(PREFIX)":"$$NF"-"$(SNYK_VERSION)" ." | "/bin/sh"}' $(NAME)
 
 test: test-linux test-alpine
 
@@ -33,6 +33,6 @@ markdown: sort
 	@cat linux alpine | sort | awk '{ print "| "$(PREFIX)":"$$NF" | "$$1" |" }'
 
 push:
-	@cat linux alpine | sort | awk '{ print "docker push "$(PREFIX)":"$$NF"" | "/bin/bash"}'
+	@cat linux alpine | sort | awk '{ print "docker push "$(PREFIX)":"$$NF"-"$(SNYK_VERSION)"" | "/bin/bash"}'
 
 .PHONY: default build build-linux build-alpine build-alpine-push check-buildkit sort sort-% test test-% markdown push

--- a/_templates/build.yml.erb
+++ b/_templates/build.yml.erb
@@ -34,6 +34,7 @@ jobs:
     - uses: docker/build-push-action@v1
       env:
         DOCKER_BUILDKIT: "1"
+        SNYK_VERSION: "<%= @snyk_version %>"
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/build.rb
+++ b/build.rb
@@ -6,7 +6,13 @@
 require "date"
 require "erb"
 require "fileutils"
+require "json"
+require 'net/http'
 
+uri = "https://api.github.com/repos/snyk/snyk/releases/latest"
+result = JSON.parse(Net::HTTP.get(URI.parse(uri)))
+
+@snyk_version = result['tag_name']
 
 @images = []
 


### PR DESCRIPTION
Instead of pulling off of /latest whenever the build action is fired, this update has the build.rb grab the tag version from latest and then set it as a static variable for the rest of the build process.

Side effect of this is whenever the build.yaml is run, it will only build with the latest base images but not change the snyk version until a new generate action is run.

This should probably be coupled with a either a watch action from here that checks for a new release against snyk cli, or dispatch action from the snyk repo to trigger a new build here.