### PR TITLE
feat: add gradle-jdk16

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:gradle-jdk12 | gradle:jdk12 |
 | snyk/snyk:gradle-jdk13 | gradle:jdk13 |
 | snyk/snyk:gradle-jdk14 | gradle:jdk14 |
+| snyk/snyk:gradle-jdk16 | gradle:jdk16 |
 | snyk/snyk:gradle-jdk8 | gradle:jdk8 |
 | snyk/snyk:sbt | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |
 | snyk/snyk:scala | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |

--- a/linux
+++ b/linux
@@ -21,6 +21,7 @@ gradle:jdk11 gradle-jdk11
 gradle:jdk12 gradle-jdk12
 gradle:jdk13 gradle-jdk13
 gradle:jdk14 gradle-jdk14
+gradle:jdk16 gradle-jdk16
 gradle:jdk8 gradle-jdk8
 hseeberger/scala-sbt:8u212_1.2.8_2.13.0 sbt
 hseeberger/scala-sbt:8u212_1.2.8_2.13.0 scala


### PR DESCRIPTION
Add an entry for Gradle running on JDK16.

Docker image: https://hub.docker.com/layers/gradle/library/gradle/jdk16/images/sha256-5d55b4835ed821fd825603340cc0244a0ef912618416d8b6400e41f25ad7babe?context=explore