### PR TITLE
Adding an explicit tag for Go 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
           - base: golang:1.16
             tag: golang-1.16
             target: linux
+          - base: golang:1.17
+            tag: golang-1.17
+            target: linux
           - base: gradle
             tag: gradle
             target: linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,9 @@ jobs:
           - base: golang:1.17
             tag: golang-1.17
             target: linux
+          - base: golang:1.18
+            tag: golang-1.18
+            target: linux
           - base: gradle
             tag: gradle
             target: linux

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:golang-1.13 | golang:1.13 |
 | snyk/snyk:golang-1.14 | golang:1.14 |
 | snyk/snyk:golang-1.15 | golang:1.15 |
+| snyk/snyk:golang-1.16 | golang:1.16 |
+| snyk/snyk:golang-1.17 | golang:1.17 |
 | snyk/snyk:gradle | gradle |
 | snyk/snyk:gradle-6.4 | gradle:6.4 |
 | snyk/snyk:gradle-6.4-jdk11 | gradle:6.4-jdk11 |
@@ -88,7 +90,7 @@ These images are published on Docker Hub at [snyk/snyk](https://hub.docker.com/r
 
 Usage requires a Snyk API token stored in an environment variable called `SNYK_TOKEN`.
 
-I've picked a somewhat random example Golang respository which is setup to use Go Modules. 
+I've picked a somewhat random example Golang respository which is setup to use Go Modules.
 
 ```console
 $ git clone git@github.com:puppetlabs/wash.git
@@ -263,4 +265,3 @@ As well as knowing the images build correctly it's useful to have a basic test s
 ```
 make test
 ```
-

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:golang-1.15 | golang:1.15 |
 | snyk/snyk:golang-1.16 | golang:1.16 |
 | snyk/snyk:golang-1.17 | golang:1.17 |
+| snyk/snyk:golang-1.18 | golang:1.18 |
 | snyk/snyk:gradle | gradle |
 | snyk/snyk:gradle-6.4 | gradle:6.4 |
 | snyk/snyk:gradle-6.4-jdk11 | gradle:6.4-jdk11 |

--- a/linux
+++ b/linux
@@ -13,6 +13,7 @@ golang:1.14 golang-1.14
 golang:1.15 golang-1.15
 golang:1.16 golang-1.16
 golang:1.17 golang-1.17
+golang:1.18 golang-1.18
 gradle
 gradle:6.4 gradle-6.4
 gradle:6.4-jdk11 gradle-6.4-jdk11

--- a/linux
+++ b/linux
@@ -12,6 +12,7 @@ golang:1.13 golang-1.13
 golang:1.14 golang-1.14
 golang:1.15 golang-1.15
 golang:1.16 golang-1.16
+golang:1.17 golang-1.17
 gradle
 gradle:6.4 gradle-6.4
 gradle:6.4-jdk11 gradle-6.4-jdk11


### PR DESCRIPTION
Adding before the 1.18 release ships and changes latest.