### PR TITLE
Add alpine driftctl flavor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,9 @@ jobs:
           - base: ruby:alpine
             tag: ruby-alpine
             target: alpine
+          - base: snyk/driftctl:v0.23.1
+            tag: driftctl
+            target: alpine
     steps:
     - uses: actions/checkout@v2
     - uses: docker/build-push-action@v1

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,6 @@
 name: Dev
 
-on: 
+on:
   push:
     branches-ignore:
       - master
@@ -13,7 +13,7 @@ jobs:
 
     - name: Install npm dependencies
       run: npm install
-    
+
     - name: Lint - check formatting
       run: npm run lint:formatting
 
@@ -238,6 +238,9 @@ jobs:
           - base: ruby:alpine
             tag: ruby-alpine
             target: alpine
+          - base: snyk/driftctl:v0.23.1
+            tag: driftctl
+            target: alpine
     steps:
     - uses: actions/checkout@v2
 
@@ -257,7 +260,7 @@ jobs:
 
     - name: Install npm dependencies
       run: npm install
-    
+
     - name: Run tests
       run: npm run test:smoke
       env:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:ruby-2.6 | ruby:2.6 |
 | snyk/snyk:ruby-2.7 | ruby:2.7 |
 | snyk/snyk:ruby-alpine | ruby:alpine |
+| snyk/snyk:driftctl | snyk/driftctl:v0.23.1 |
 | snyk/snyk:linux | ubuntu |
 
 ### Usage

--- a/alpine
+++ b/alpine
@@ -9,3 +9,4 @@ docker:latest docker-latest
 docker:latest docker
 python:alpine python-alpine
 ruby:alpine ruby-alpine
+snyk/driftctl:v0.23.1 driftctl

--- a/test/smoke.spec.ts
+++ b/test/smoke.spec.ts
@@ -10,4 +10,17 @@ describe('smoke tests', () => {
     expect(stdout).toMatch(versionRegex);
     expect(stderr).toBe('');
   });
+
+  if (process.env.IMAGE_TAG === 'driftctl') {
+    it('ensure we have a proper driftctl binary installed in /bin/', async () => {
+      const imageName = process.env.IMAGE_TAG;
+      const { stdout, stderr } = await runContainer(
+        imageName,
+        '/bin/driftctl version',
+      );
+
+      expect(stdout).toContain('v0.23.1');
+      expect(stderr).toBe('');
+    });
+  }
 });


### PR DESCRIPTION
This PR add a new flavor of the snyk CLI based on the driftctl image.
That allows us to reuse existing binary instead of downloading driftctl each time we launch the CLI in a docker context.

I'm not sure about the process of adding a new flavor here, please let me know if I missed something.