### PR TITLE
Upgrade SBT images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,10 +98,10 @@ jobs:
           - base: gradle:jdk8
             tag: gradle-jdk8
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: sbt
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: scala
             target: linux
           - base: java

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -103,10 +103,10 @@ jobs:
           - base: gradle:jdk8
             tag: gradle-jdk8
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: sbt
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: scala
             target: linux
           - base: java

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:gradle-jdk14 | gradle:jdk14 |
 | snyk/snyk:gradle-jdk16 | gradle:jdk16 |
 | snyk/snyk:gradle-jdk8 | gradle:jdk8 |
-| snyk/snyk:sbt | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |
-| snyk/snyk:scala | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |
+| snyk/snyk:sbt | hseeberger/scala-sbt:8u312_1.6.2_3.1.1 |
+| snyk/snyk:scala | hseeberger/scala-sbt:8u312_1.6.2_3.1.1 |
 | snyk/snyk:java | java |
 | snyk/snyk:maven | maven |
 | snyk/snyk:maven-3-jdk-11 | maven:3-jdk-11 |

--- a/linux
+++ b/linux
@@ -23,8 +23,8 @@ gradle:jdk13 gradle-jdk13
 gradle:jdk14 gradle-jdk14
 gradle:jdk16 gradle-jdk16
 gradle:jdk8 gradle-jdk8
-hseeberger/scala-sbt:8u212_1.2.8_2.13.0 sbt
-hseeberger/scala-sbt:8u212_1.2.8_2.13.0 scala
+hseeberger/scala-sbt:8u312_1.6.2_3.1.1 sbt
+hseeberger/scala-sbt:8u312_1.6.2_3.1.1 scala
 java
 maven
 maven:3-jdk-11 maven-3-jdk-11


### PR DESCRIPTION
Using an old version of SBT causes dependency check to fail with deep paths when using thee fallback dependency parser. SBT 1.4.x upward work fine once the user has set asciiGraphWidth.

Also the old version of SBT and JVM that are used have bug and security issues that have been fixed in later versions 

See https://github.com/sbt/sbt/blob/fe5497938a8b2898dcbab49b60e0f2ef53b06c29/notes/1.0.0.markdown?plain=1#L71