### PR TITLE
Support poetry.lock files

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,7 +28,7 @@ else
                 out=$(pipenv update)
             fi
         fi
-        if [ -f "pyproject.toml" ]; then
+        if [ -f "pyproject.toml" ] && ! [ -f "poetry.lock" ]; then
             if ! [ -x "$(command -v poetry)" ]; then
                 pip install poetry > /dev/null 2>&1
             fi


### PR DESCRIPTION
The current entrypoint does not take `poetry.lock` files into account when scanning Poetry projects. This causes it to run `poetry install` everytime which can lead to very high execution times in some cases where libraries have to be built from source. 

This PR will add an additional check for the absence of `poetry.lock` before running `poetry install`.