### PR TITLE
Include Node 16 image on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:node-12 | node:12 |
 | snyk/snyk:node-13 | node:13 |
 | snyk/snyk:node-14 | node:14 |
+| snyk/snyk:node-16 | node:16 |
 | snyk/snyk:node-8 | node:8 |
 | snyk/snyk:python | python |
 | snyk/snyk:python-2.7 | python:2.7 |


### PR DESCRIPTION
as on docker hub node 16 image is present but not updated on readme
https://hub.docker.com/r/snyk/snyk/tags?page=1&name=node