### PR TITLE
fix: allow to use a command including spaces

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -89,4 +89,4 @@ if [ "$INPUT_COMMAND" = "test" -a "$INPUT_SARIF" = "true" ]; then
     fi
 fi
 
-exec $@ $JSON_OUTPUT $SARIF_OUTPUT
+exec "$@" $JSON_OUTPUT $SARIF_OUTPUT


### PR DESCRIPTION
## Summary

A container from `snyk/snyk` image cannot be handled a command including spaces (e.g.: `snyk monitor --org=xxxxx --project-name="having spaces from cli`).

Just using CLI run successfully...

```bash
$ snyk monitor --org=xxxxxx --project-name="having spaces from cli"

Monitoring /xxx/samples (com.example.xxx.samples:parent)...

Explore this snapshot at https://app.snyk.io/org/xxxxxx/project/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/history/yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy

Tip: Detected Maven project, are you using modules? Use --maven-aggregate-project to scan each project. Alternatively use --all-projects to scan Maven and other types of projects.

Notifications about newly disclosed issues related to these dependencies will be emailed to you.
```

however, on container, it fails.

```bash
$ docker container run --rm -it --env SNYK_TOKEN snyk/snyk:maven snyk monitor --org=xxxxxx --project-name="having spaces from container"
The following option combination is not currently supported: multiple paths + project-name
```

On container, the following command seems to be executed.

```bash
$ snyk monitor --org=xxxxxx --project=name=having spaces from container
The following option combination is not currently supported: multiple paths + project-name
```

## Background of fixes

When running `snyk/snyk:maven` image on Azure Pipeline as [a container job](https://docs.microsoft.com/ja-jp/azure/devops/pipelines/process/container-phases?view=azure-devops), the started container from `snyk/snyk:maven` goes down immediately and any of user's defined steps cannot be executed. When running a container job of Azure Pipeline, the pipeline execute node.js script (`"/__a/externals/node/bin/node" -e "setInterval(function(){}, 24 * 60 * 60 * 1000);"`) to continue to launch a container and perform their own setup process (see logs in the bellow). Since this node script includes spaces, a container from `snyk/snyk` image goes down immediately. This setup process cannot be controlled by pipeline user.

### `pipeline.yml` 

```yaml
trigger:
- analyze/snyk-cli-scan-hosted-container

pool:
  vmImage: ubuntu-latest

container: snyk/snyk:maven-3-jdk-8

variables:
- group: snyk-poc

steps:
- script: whoami
# - script: |
#     export SNYK_TOKEN=$(SNYK_TOKEN)
#     mvn install -DskipTests
#     snyk test \
#       --org=$(SNYK_ORG) \
#       --all-projects \
#       --fail-fast \
#       --print-deps
```


### Error Logs from Azure Pipeline

The following is logs of `initialize containers` phase that is automatically executed by Azure Pipeline when using Azure Pipeline's Container Job and cannot be controlled by the user. The execution of the user-defined step that would have been executed after this is skipped

<details>
<summary>error logs</summary>
<pre><code>
2022-09-12T01:55:17.0081667Z ##[section]Starting: Initialize containers
2022-09-12T01:55:17.0419227Z ##[command]/usr/bin/docker version --format '{{.Server.APIVersion}}'
2022-09-12T01:55:17.2994726Z '1.41'
2022-09-12T01:55:17.3017203Z Docker daemon API version: '1.41'
2022-09-12T01:55:17.3017592Z ##[command]/usr/bin/docker version --format '{{.Client.APIVersion}}'
2022-09-12T01:55:17.3446923Z '1.41'
2022-09-12T01:55:17.3479809Z Docker client API version: '1.41'
2022-09-12T01:55:17.3498285Z ##[command]/usr/bin/docker ps --all --quiet --no-trunc --filter "label=cdabb5"
2022-09-12T01:55:17.3901828Z ##[command]/usr/bin/docker network prune --force --filter "label=cdabb5"
2022-09-12T01:55:17.4380960Z ##[command]/usr/bin/docker pull snyk/snyk:maven-3-jdk-8
2022-09-12T01:55:21.5336469Z maven-3-jdk-8: Pulling from snyk/snyk
2022-09-12T01:55:21.5339746Z 001c52e26ad5: Pulling fs layer
2022-09-12T01:55:21.5340042Z d9d4b9b6e964: Pulling fs layer
2022-09-12T01:55:21.5343202Z 2068746827ec: Pulling fs layer
2022-09-12T01:55:21.5343668Z 9daef329d350: Pulling fs layer
2022-09-12T01:55:21.5344884Z d85151f15b66: Pulling fs layer
2022-09-12T01:55:21.5345279Z 52a8c426d30b: Pulling fs layer
2022-09-12T01:55:21.5345631Z 9daef329d350: Waiting
2022-09-12T01:55:21.5346026Z d85151f15b66: Waiting
2022-09-12T01:55:21.5346369Z 8754a66e0050: Pulling fs layer
2022-09-12T01:55:21.5346687Z 39bc17d35d34: Pulling fs layer
2022-09-12T01:55:21.5347005Z 3262383b2477: Pulling fs layer
2022-09-12T01:55:21.5347337Z 25bbf367674f: Pulling fs layer
2022-09-12T01:55:21.5347640Z 52a8c426d30b: Waiting
2022-09-12T01:55:21.5347926Z 8754a66e0050: Waiting
2022-09-12T01:55:21.5348271Z 39bc17d35d34: Waiting
2022-09-12T01:55:21.5348566Z 3262383b2477: Waiting
2022-09-12T01:55:21.5348859Z c9c8a1c88919: Pulling fs layer
2022-09-12T01:55:21.5349215Z 5f1e09d490a7: Pulling fs layer
2022-09-12T01:55:21.5349539Z a69426798bff: Pulling fs layer
2022-09-12T01:55:21.5349843Z 25bbf367674f: Waiting
2022-09-12T01:55:21.5350130Z c9c8a1c88919: Waiting
2022-09-12T01:55:21.5350444Z 5f1e09d490a7: Waiting
2022-09-12T01:55:21.5350707Z a69426798bff: Waiting
2022-09-12T01:55:22.6087742Z d9d4b9b6e964: Verifying Checksum
2022-09-12T01:55:22.6093979Z d9d4b9b6e964: Download complete
2022-09-12T01:55:22.6535409Z 2068746827ec: Verifying Checksum
2022-09-12T01:55:22.6544147Z 2068746827ec: Download complete
2022-09-12T01:55:22.9978341Z 001c52e26ad5: Verifying Checksum
2022-09-12T01:55:22.9988036Z 001c52e26ad5: Download complete
2022-09-12T01:55:23.7476404Z d85151f15b66: Verifying Checksum
2022-09-12T01:55:23.7477527Z d85151f15b66: Download complete
2022-09-12T01:55:24.0105568Z 52a8c426d30b: Verifying Checksum
2022-09-12T01:55:24.0108187Z 52a8c426d30b: Download complete
2022-09-12T01:55:25.1254517Z 39bc17d35d34: Verifying Checksum
2022-09-12T01:55:25.1270456Z 39bc17d35d34: Download complete
2022-09-12T01:55:25.4832360Z 001c52e26ad5: Pull complete
2022-09-12T01:55:25.7420039Z 8754a66e0050: Verifying Checksum
2022-09-12T01:55:25.7420675Z 8754a66e0050: Download complete
2022-09-12T01:55:26.1275983Z 3262383b2477: Verifying Checksum
2022-09-12T01:55:26.1276727Z 3262383b2477: Download complete
2022-09-12T01:55:27.0422018Z 25bbf367674f: Verifying Checksum
2022-09-12T01:55:27.0422778Z 25bbf367674f: Download complete
2022-09-12T01:55:27.3768331Z c9c8a1c88919: Verifying Checksum
2022-09-12T01:55:27.3775142Z c9c8a1c88919: Download complete
2022-09-12T01:55:27.9696704Z d9d4b9b6e964: Pull complete
2022-09-12T01:55:28.3653120Z 5f1e09d490a7: Verifying Checksum
2022-09-12T01:55:28.3657305Z 5f1e09d490a7: Download complete
2022-09-12T01:55:28.3809670Z 2068746827ec: Pull complete
2022-09-12T01:55:29.4604394Z 9daef329d350: Verifying Checksum
2022-09-12T01:55:29.4604897Z 9daef329d350: Download complete
2022-09-12T01:55:30.2447174Z a69426798bff: Verifying Checksum
2022-09-12T01:55:30.2447675Z a69426798bff: Download complete
2022-09-12T01:55:33.4426733Z 9daef329d350: Pull complete
2022-09-12T01:55:33.9784345Z d85151f15b66: Pull complete
2022-09-12T01:55:34.0759677Z 52a8c426d30b: Pull complete
2022-09-12T01:55:37.0289075Z 8754a66e0050: Pull complete
2022-09-12T01:55:37.2228717Z 39bc17d35d34: Pull complete
2022-09-12T01:55:37.7904505Z 3262383b2477: Pull complete
2022-09-12T01:55:37.7915214Z 25bbf367674f: Pull complete
2022-09-12T01:55:37.7923993Z c9c8a1c88919: Pull complete
2022-09-12T01:55:37.7924592Z 5f1e09d490a7: Pull complete
2022-09-12T01:55:38.1309977Z a69426798bff: Pull complete
2022-09-12T01:55:38.1371503Z Digest: sha256:c5091b679eb24a03f51fafe451b7e08438f4dfe5a6cefd8084cfe323b0e8ac19
2022-09-12T01:55:38.1394221Z Status: Downloaded newer image for snyk/snyk:maven-3-jdk-8
2022-09-12T01:55:38.1409108Z docker.io/snyk/snyk:maven-3-jdk-8
2022-09-12T01:55:38.1466194Z ##[command]/usr/bin/docker info -f "{{range .Plugins.Network}}{{println .}}{{end}}"
2022-09-12T01:55:41.7084103Z bridge
2022-09-12T01:55:41.7085237Z host
2022-09-12T01:55:41.7085644Z ipvlan
2022-09-12T01:55:41.7085995Z macvlan
2022-09-12T01:55:41.7086413Z null
2022-09-12T01:55:41.7086776Z overlay
2022-09-12T01:55:41.7108713Z ##[command]/usr/bin/docker network create --label cdabb5 vsts_network_abcdefghijklmnopqrstuvwxyz123456
2022-09-12T01:55:41.7970631Z 612e218c925f6b5bd8f2001237bbdea1f5c386abd09eb1ffdbdc45850fb1843c
2022-09-12T01:55:41.8262877Z ##[command]/usr/bin/docker inspect --format="{{index .Config.Labels \"com.azure.dev.pipelines.agent.handler.node.path\"}}" snyk/snyk:maven-3-jdk-8
2022-09-12T01:55:41.8753050Z ##[command]/usr/bin/docker create --name 0b9da084c35f4aa58fae9a40da0e049b_snyksnykmaven3jdk8_927cee --label cdabb5 --network vsts_network_abcdefghijklmnopqrstuvwxyz123456  -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/vsts/work/1":"/__w/1" -v "/home/vsts/work/_temp":"/__w/_temp" -v "/home/vsts/work/_tasks":"/__w/_tasks" -v "/opt/hostedtoolcache":"/__t" -v "/home/vsts/agents/2.210.0/externals":"/__a/externals":ro -v "/home/vsts/work/.taskkey":"/__w/.taskkey" snyk/snyk:maven-3-jdk-8 "/__a/externals/node/bin/node" -e "setInterval(function(){}, 24 * 60 * 60 * 1000);"
2022-09-12T01:55:41.9417119Z f77128b8aa8ca8c2df2d3f05178b39f19cffaff840c1e2d1dec7c97b672d702f
2022-09-12T01:55:41.9453309Z ##[command]/usr/bin/docker start f77128b8aa8ca8c2df2d3f05178b39f19cffaff840c1e2d1dec7c97b672d702f
2022-09-12T01:55:42.3951594Z f77128b8aa8ca8c2df2d3f05178b39f19cffaff840c1e2d1dec7c97b672d702f
2022-09-12T01:55:42.3961886Z ##[command]/usr/bin/docker ps --all --filter id=f77128b8aa8ca8c2df2d3f05178b39f19cffaff840c1e2d1dec7c97b672d702f --filter status=running --no-trunc --format "{{.ID}} {{.Status}}"
2022-09-12T01:55:42.4352509Z f77128b8aa8ca8c2df2d3f05178b39f19cffaff840c1e2d1dec7c97b672d702f Up Less than a second
2022-09-12T01:55:42.4410731Z ##[command]/usr/bin/docker exec  f77128b8aa8ca8c2df2d3f05178b39f19cffaff840c1e2d1dec7c97b672d702f sh -c "command -v bash"
2022-09-12T01:55:42.5785553Z ##[error]Docker-exec executed: `sh -c "command -v bash"`; container id: `f77128b8aa8ca8c2df2d3f05178b39f19cffaff840c1e2d1dec7c97b672d702f`; exit code: `137`; command does not have output
2022-09-12T01:55:42.5803870Z ##[section]Finishing: Initialize containers
</code></pre>
</details>
