### PR TITLE
chore: java image removal and test fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,9 +113,6 @@ jobs:
           - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
             tag: scala
             target: linux
-          - base: java
-            tag: java
-            target: linux
           - base: maven
             tag: maven
             target: linux

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -112,9 +112,6 @@ jobs:
           - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
             tag: scala
             target: linux
-          - base: java
-            tag: java
-            target: linux
           - base: maven
             tag: maven
             target: linux

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:gradle-jdk8 | gradle:jdk8 |
 | snyk/snyk:sbt | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |
 | snyk/snyk:scala | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |
-| snyk/snyk:java | java |
 | snyk/snyk:maven | maven |
 | snyk/snyk:maven-3-jdk-11 | maven:3-jdk-11 |
 | snyk/snyk:maven-3-jdk-12 | maven:3-jdk-12 |
@@ -219,6 +218,8 @@ Next steps:
 - Run `snyk test` as part of your CI/test.
 ```
 
+#### `snyk/snyk:java` image
+Following [the deprecation of the docker Java image](https://github.com/docker-library/openjdk/issues/505) and with a lack of an alternative image, we had to remove the Java image.
 
 ### Running bootstrap commands
 

--- a/linux
+++ b/linux
@@ -28,7 +28,6 @@ gradle:jdk17 gradle-jdk17
 gradle:jdk8 gradle-jdk8
 hseeberger/scala-sbt:8u212_1.2.8_2.13.0 sbt
 hseeberger/scala-sbt:8u212_1.2.8_2.13.0 scala
-java
 maven
 maven:3-jdk-11 maven-3-jdk-11
 maven:3-jdk-12 maven-3-jdk-12

--- a/test/image-specific/python-3-poetry.spec.ts
+++ b/test/image-specific/python-3-poetry.spec.ts
@@ -1,6 +1,6 @@
 import { runContainer } from '../runContainer';
 
-jest.setTimeout(1000 * 60);
+jest.setTimeout(1000 * 90);
 
 it('can do `snyk test` on a poetry project', async () => {
   const imageName = 'python-3.8';
@@ -13,7 +13,7 @@ it('can do `snyk test` on a poetry project', async () => {
   expect(stdout).toContain('Testing /app...');
   expect(stdout).toContain('poetry-fixtures-project');
   expect(stdout).toContain(
-    'Regular Expression Denial of Service (ReDoS) [Medium Severity][https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in jinja2@2.11.2',
+    'Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994]',
   );
   expect(stderr).toBe('');
 });
@@ -29,7 +29,7 @@ it('can do `snyk test` on a poetry project with lockfile', async () => {
   expect(stdout).toContain('Testing /app...');
   expect(stdout).toContain('poetry-fixtures-project');
   expect(stdout).toContain(
-    'Regular Expression Denial of Service (ReDoS) [Medium Severity][https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994] in jinja2@2.11.2',
+    'Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994]',
   );
   expect(stderr).toBe('');
 });

--- a/test/smoke.spec.ts
+++ b/test/smoke.spec.ts
@@ -6,7 +6,7 @@ describe('smoke tests', () => {
   it('can do `snyk version`', async () => {
     const imageName = process.env.IMAGE_TAG;
     const { stdout, stderr } = await runContainer(imageName, 'snyk version');
-    const versionRegex = /1\.\d\d\d\.0 \(standalone\)/;
+    const versionRegex = /1\.\d\d\d\d\.0 \(standalone\)/;
     expect(stdout).toMatch(versionRegex);
     expect(stderr).toBe('');
   });


### PR DESCRIPTION
Java docker image is deprecated. With no alternative images available, we're removing the java image. Existing one in dockerhub still remains.
Also contains many test fixes:
* As Snyk CLI is now version 1.1000.0, the regex in the smoke tests needs to be changed. Also fixed some broken tests
* URL change