### PR TITLE
chore: enable spaces in cmd arguments …

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ Next steps:
 - Run `snyk test` as part of your CI/test.
 ```
 
+#### Note on using spaces in arguments
+When using argument values that include spaces please wrap the whole command in quotes as well as the individual argument itself.
+
+```console
+$ docker run --rm -it --env SNYK_TOKEN -v $(PWD):/app snyk/snyk:golang 'snyk code test --project-name="My Project" --org=MyOrg'
+```
+
 #### `snyk/snyk:java` image
 Following [the deprecation of the docker Java image](https://github.com/docker-library/openjdk/issues/505) and with a lack of an alternative image, we had to remove the Java image.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -89,4 +89,7 @@ if [ "$INPUT_COMMAND" = "test" -a "$INPUT_SARIF" = "true" ]; then
     fi
 fi
 
-exec $@ $JSON_OUTPUT $SARIF_OUTPUT
+# create the command to invocate as an intermediate string and use eval to run exec with a single string
+# This supports both arguments with spaces and usages where multiple CLI arguments are given as one argument to the entrypoint script.
+cmd_string="$* $JSON_OUTPUT $SARIF_OUTPUT"
+eval "exec ${cmd_string}"

--- a/test/smoke.spec.ts
+++ b/test/smoke.spec.ts
@@ -1,4 +1,5 @@
 import { runContainer } from './runContainer';
+import { execSync } from 'child_process';
 
 jest.setTimeout(1000 * 90);
 
@@ -9,5 +10,51 @@ describe('smoke tests', () => {
     const versionRegex = /1\.\d\d\d\d\.0 \(standalone\)/;
     expect(stdout).toMatch(versionRegex);
     expect(stderr).toBe('');
+  });
+
+  it('Entrypoint supports multiple args in a single arg (as it is provided by github actions)', async () => {
+    const expected = execSync('ls -a -l -h').toString();
+    const actual = execSync(
+      __dirname + '/../docker-entrypoint.sh ls "-a -l" -h',
+    ).toString();
+    expect(actual).toEqual(expected);
+  });
+
+  it('Entrypoint supports spaces in arguments when complete cmd is wrapped in single quotes', async () => {
+    const expected = execSync('date "+DATE: %Y-%m-%d"').toString();
+    const actual = execSync(
+      __dirname + '/../docker-entrypoint.sh \'date "+DATE: %Y-%m-%d"\'',
+    ).toString();
+    expect(actual).toEqual(expected);
+  });
+
+  it('Entrypoint adding JSON_OUTPUT', async () => {
+    const actual = execSync(
+      __dirname + '/../docker-entrypoint.sh echo -n "something else"',
+      {
+        env: {
+          ...process.env,
+          INPUT_COMMAND: 'test',
+          INPUT_JSON: 'true',
+        },
+      },
+    ).toString();
+    expect(actual).toEqual('something else --json-file-output=snyk.json');
+  });
+
+  it('Entrypoint adding SARIF_OUTPUT', async () => {
+    const actual = execSync(
+      __dirname +
+        '/../docker-entrypoint.sh \'echo -n "something else" --file=filename\'',
+      {
+        env: {
+          ...process.env,
+          SARIF_OUTPUT: '--sarif-file-output=snyk.sarif',
+        },
+      },
+    ).toString();
+    expect(actual).toEqual(
+      'something else --file=filename --sarif-file-output=snyk.sarif',
+    );
   });
 });


### PR DESCRIPTION
… while supporting arbitrary clustered arguments

This should enable the usage as described in #35 and at the same time enable multiple arguments being combined in one argument.