### PR TITLE
fix: upgrade scala-sbt base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,10 +107,10 @@ jobs:
           - base: gradle:jdk8
             tag: gradle-jdk8
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: sbt
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: scala
             target: linux
           - base: maven

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -106,10 +106,10 @@ jobs:
           - base: gradle:jdk8
             tag: gradle-jdk8
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: sbt
             target: linux
-          - base: hseeberger/scala-sbt:8u212_1.2.8_2.13.0
+          - base: hseeberger/scala-sbt:8u312_1.6.2_3.1.1
             tag: scala
             target: linux
           - base: maven

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:gradle-jdk16 | gradle:jdk16 |
 | snyk/snyk:gradle-jdk17 | gradle:jdk17 |
 | snyk/snyk:gradle-jdk8 | gradle:jdk8 |
-| snyk/snyk:sbt | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |
-| snyk/snyk:scala | hseeberger/scala-sbt:8u212_1.2.8_2.13.0 |
+| snyk/snyk:sbt | hseeberger/scala-sbt:8u312_1.6.2_3.1.1 |
+| snyk/snyk:scala | hseeberger/scala-sbt:8u312_1.6.2_3.1.1 |
 | snyk/snyk:maven | maven |
 | snyk/snyk:maven-3-jdk-11 | maven:3-jdk-11 |
 | snyk/snyk:maven-3-jdk-12 | maven:3-jdk-12 |

--- a/linux
+++ b/linux
@@ -26,8 +26,8 @@ gradle:jdk14 gradle-jdk14
 gradle:jdk16 gradle-jdk16
 gradle:jdk17 gradle-jdk17
 gradle:jdk8 gradle-jdk8
-hseeberger/scala-sbt:8u212_1.2.8_2.13.0 sbt
-hseeberger/scala-sbt:8u212_1.2.8_2.13.0 scala
+hseeberger/scala-sbt:8u312_1.6.2_3.1.1 sbt
+hseeberger/scala-sbt:8u312_1.6.2_3.1.1 scala
 maven
 maven:3-jdk-11 maven-3-jdk-11
 maven:3-jdk-12 maven-3-jdk-12


### PR DESCRIPTION
**What?**
Upgrade the base image for the `snyk/snyk:sbt` and `snyk/snyk:scala` images from `hseeberger/scala-sbt:8u212_1.2.8_2.13.0` to `hseeberger/scala-sbt:8u312_1.6.2_3.1.1`

**Why?**
To fix a critical vulnerability in these images.