### PR TITLE
feat: delete unsupported Python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,12 +176,6 @@ jobs:
           - base: python
             tag: python
             target: linux
-          - base: python:2.7
-            tag: python-2.7
-            target: linux
-          - base: python:3.6
-            tag: python-3.6
-            target: linux
           - base: python:3.7
             tag: python-3.7
             target: linux

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ A build toolchain for Snyk Docker images.
 | snyk/snyk:node-16 | node:16 |
 | snyk/snyk:node-8 | node:8 |
 | snyk/snyk:python | python |
-| snyk/snyk:python-2.7 | python:2.7 |
-| snyk/snyk:python-3.6 | python:3.6 |
 | snyk/snyk:python-3.7 | python:3.7 |
 | snyk/snyk:python-3.8 | python:3.8 |
 | snyk/snyk:python-3.9 | python:3.9 |

--- a/linux
+++ b/linux
@@ -49,8 +49,6 @@ node:15 node-15
 node:16 node-16
 node:8 node-8
 python
-python:2.7 python-2.7
-python:3.6 python-3.6
 python:3.7 python-3.7
 python:3.8 python-3.8
 python:3.9 python-3.9


### PR DESCRIPTION
Python versions 2.7 and 3.6 are end of life.