### PR TITLE
chore: update entrypoint and dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,17 +119,11 @@ jobs:
           - base: maven:3-jdk-11
             tag: maven-3-jdk-11
             target: linux
-          - base: maven:3-jdk-12
-            tag: maven-3-jdk-12
+          - base: maven:3-eclipse-temurin-17
+            tag: maven-3-jdk-17
             target: linux
-          - base: maven:3-jdk-13
-            tag: maven-3-jdk-13
-            target: linux
-          - base: maven:3-jdk-14
-            tag: maven-3-jdk-14
-            target: linux
-          - base: maven:3-openjdk-17
-            tag: maven-3-openjdk-17
+          - base: maven:3-eclipse-temurin-19
+            tag: maven-3-jdk-17
             target: linux
           - base: maven:3-jdk-8
             tag: maven-3-jdk-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,12 @@ jobs:
           - base: golang:1.18
             tag: golang-1.18
             target: linux
+          - base: golang:1.19
+            tag: golang-1.19
+            target: linux
+          - base: golang:1.20
+            tag: golang-1.20
+            target: linux
           - base: gradle
             tag: gradle
             target: linux
@@ -123,7 +129,7 @@ jobs:
             tag: maven-3-jdk-17
             target: linux
           - base: maven:3-eclipse-temurin-19
-            tag: maven-3-jdk-17
+            tag: maven-3-jdk-19
             target: linux
           - base: maven:3-jdk-8
             tag: maven-3-jdk-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
             tag: ruby-alpine
             target: alpine
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: docker/build-push-action@v1
       env:
         DOCKER_BUILDKIT: "1"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -70,6 +70,18 @@ jobs:
           - base: golang:1.16
             tag: golang-1.16
             target: linux
+          - base: golang:1.17
+            tag: golang-1.17
+            target: linux
+          - base: golang:1.18
+            tag: golang-1.18
+            target: linux
+          - base: golang:1.19
+            tag: golang-1.19
+            target: linux
+          - base: golang:1.20
+            tag: golang-1.20
+            target: linux
           - base: gradle
             tag: gradle
             target: linux
@@ -118,14 +130,11 @@ jobs:
           - base: maven:3-jdk-11
             tag: maven-3-jdk-11
             target: linux
-          - base: maven:3-jdk-12
-            tag: maven-3-jdk-12
+          - base: maven:3-eclipse-temurin-17
+            tag: maven-3-jdk-17
             target: linux
-          - base: maven:3-jdk-13
-            tag: maven-3-jdk-13
-            target: linux
-          - base: maven:3-jdk-14
-            tag: maven-3-jdk-14
+          - base: maven:3-eclipse-temurin-19
+            tag: maven-3-jdk-17
             target: linux
           - base: maven:3-openjdk-17
             tag: maven-3-openjdk-17

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -136,9 +136,6 @@ jobs:
           - base: maven:3-eclipse-temurin-19
             tag: maven-3-jdk-17
             target: linux
-          - base: maven:3-openjdk-17
-            tag: maven-3-openjdk-17
-            target: linux
           - base: maven:3-jdk-8
             tag: maven-3-jdk-8
             target: linux

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install npm dependencies
       run: npm install

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -134,7 +134,7 @@ jobs:
             tag: maven-3-jdk-17
             target: linux
           - base: maven:3-eclipse-temurin-19
-            tag: maven-3-jdk-17
+            tag: maven-3-jdk-19
             target: linux
           - base: maven:3-jdk-8
             tag: maven-3-jdk-8

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -12,7 +12,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/node_modules
+**/.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ RUN curl -o ./snyk-alpine https://static.snyk.io/cli/latest/snyk-alpine && \
 
 FROM parent as alpine
 RUN apk update && apk upgrade --no-cache
-RUN apk add --no-cache libstdc++
+RUN apk add --no-cache libstdc++ git
 COPY --from=snyk-alpine /usr/local/bin/snyk /usr/local/bin/snyk
 
 
 FROM parent as linux
 COPY --from=snyk /usr/local/bin/snyk /usr/local/bin/snyk
-RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ CMD ["snyk", "test"]
 
 
 FROM ubuntu as snyk
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl ca-certificates git
+RUN apt-get update  && apt-get install -y curl ca-certificates
 RUN curl -o ./snyk-linux https://static.snyk.io/cli/latest/snyk-linux && \
     curl -o ./snyk-linux.sha256 https://static.snyk.io/cli/latest/snyk-linux.sha256 && \
     sha256sum -c snyk-linux.sha256 && \
@@ -21,14 +21,12 @@ RUN curl -o ./snyk-linux https://static.snyk.io/cli/latest/snyk-linux && \
     chmod +x /usr/local/bin/snyk
 
 FROM alpine as snyk-alpine
-RUN apk update && apk upgrade --no-cache
-RUN apk add --no-cache curl git
+RUN apk update && apk add --no-cache curl git
 RUN curl -o ./snyk-alpine https://static.snyk.io/cli/latest/snyk-alpine && \
     curl -o ./snyk-alpine.sha256 https://static.snyk.io/cli/latest/snyk-alpine.sha256 && \
     sha256sum -c snyk-alpine.sha256 && \
     mv snyk-alpine /usr/local/bin/snyk && \
     chmod +x /usr/local/bin/snyk
-
 
 FROM parent as alpine
 RUN apk update && apk upgrade --no-cache
@@ -38,4 +36,7 @@ COPY --from=snyk-alpine /usr/local/bin/snyk /usr/local/bin/snyk
 
 FROM parent as linux
 COPY --from=snyk /usr/local/bin/snyk /usr/local/bin/snyk
-RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates git
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y ca-certificates git
+RUN apt-get auto-remove -y && apt-get clean -y && rm -rf /var/lib/apt/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ CMD ["snyk", "test"]
 
 
 FROM ubuntu as snyk
-RUN apt-get update && apt-get install -y curl ca-certificates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl ca-certificates git
 RUN curl -o ./snyk-linux https://static.snyk.io/cli/latest/snyk-linux && \
     curl -o ./snyk-linux.sha256 https://static.snyk.io/cli/latest/snyk-linux.sha256 && \
     sha256sum -c snyk-linux.sha256 && \
@@ -21,7 +21,8 @@ RUN curl -o ./snyk-linux https://static.snyk.io/cli/latest/snyk-linux && \
     chmod +x /usr/local/bin/snyk
 
 FROM alpine as snyk-alpine
-RUN apk add --no-cache curl
+RUN apk update && apk upgrade --no-cache
+RUN apk add --no-cache curl git
 RUN curl -o ./snyk-alpine https://static.snyk.io/cli/latest/snyk-alpine && \
     curl -o ./snyk-alpine.sha256 https://static.snyk.io/cli/latest/snyk-alpine.sha256 && \
     sha256sum -c snyk-alpine.sha256 && \
@@ -30,10 +31,11 @@ RUN curl -o ./snyk-alpine https://static.snyk.io/cli/latest/snyk-alpine && \
 
 
 FROM parent as alpine
+RUN apk update && apk upgrade --no-cache
 RUN apk add --no-cache libstdc++
 COPY --from=snyk-alpine /usr/local/bin/snyk /usr/local/bin/snyk
 
 
 FROM parent as linux
 COPY --from=snyk /usr/local/bin/snyk /usr/local/bin/snyk
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -89,6 +89,9 @@ if [ "$INPUT_COMMAND" = "test" -a "$INPUT_SARIF" = "true" ]; then
     fi
 fi
 
+# add workdir as git safe directory
+git config --global --add safe.directory * || true # don't fail
+
 # create the command to invocate as an intermediate string and use eval to run exec with a single string
 # This supports both arguments with spaces and usages where multiple CLI arguments are given as one argument to the entrypoint script.
 cmd_string="$* $JSON_OUTPUT $SARIF_OUTPUT"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if [ "$INPUT_COMMAND" = "test" -a "$INPUT_SARIF" = "true" ]; then
 fi
 
 # add workdir as git safe directory
-git config --global --add safe.directory * || true # don't fail
+git config --global --add safe.directory "*" || true # don't fail
 
 # create the command to invocate as an intermediate string and use eval to run exec with a single string
 # This supports both arguments with spaces and usages where multiple CLI arguments are given as one argument to the entrypoint script.

--- a/linux
+++ b/linux
@@ -31,12 +31,11 @@ gradle:jdk8 gradle-jdk8
 hseeberger/scala-sbt:8u212_1.2.8_2.13.0 sbt
 hseeberger/scala-sbt:8u212_1.2.8_2.13.0 scala
 maven
-maven:3-jdk-11 maven-3-jdk-11
-maven:3-jdk-12 maven-3-jdk-12
-maven:3-jdk-13 maven-3-jdk-13
-maven:3-jdk-14 maven-3-jdk-14
-maven:3-openjdk-17 maven-3-openjdk-17
 maven:3-jdk-8 maven-3-jdk-8
+maven:3-jdk-11 maven-3-jdk-11
+maven:3-eclipse-temurin-17 maven-3-jdk-17
+maven:3-eclipse-temurin-19 maven-3-jdk-19
+maven:3-openjdk-17 maven-3-openjdk-17
 mcr.microsoft.com/dotnet/core/sdk dotnet
 mcr.microsoft.com/dotnet/core/sdk:2.1 dotnet-2.1
 mcr.microsoft.com/dotnet/core/sdk:2.2 dotnet-2.2

--- a/linux
+++ b/linux
@@ -14,6 +14,8 @@ golang:1.15 golang-1.15
 golang:1.16 golang-1.16
 golang:1.17 golang-1.17
 golang:1.18 golang-1.18
+golang:1.19 golang-1.19
+golang:1.20 golang-1.20
 gradle
 gradle:6.4 gradle-6.4
 gradle:6.4-jdk11 gradle-6.4-jdk11

--- a/linux
+++ b/linux
@@ -35,7 +35,6 @@ maven:3-jdk-8 maven-3-jdk-8
 maven:3-jdk-11 maven-3-jdk-11
 maven:3-eclipse-temurin-17 maven-3-jdk-17
 maven:3-eclipse-temurin-19 maven-3-jdk-19
-maven:3-openjdk-17 maven-3-openjdk-17
 mcr.microsoft.com/dotnet/core/sdk dotnet
 mcr.microsoft.com/dotnet/core/sdk:2.1 dotnet-2.1
 mcr.microsoft.com/dotnet/core/sdk:2.2 dotnet-2.2

--- a/test/image-specific/python-3-poetry.spec.ts
+++ b/test/image-specific/python-3-poetry.spec.ts
@@ -15,7 +15,9 @@ it('can do `snyk test` on a poetry project', async () => {
   expect(stdout).toContain(
     'Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994]',
   );
-  expect(stderr).toBe('Skipping virtualenv creation, as specified in config file.\n');
+  expect(stderr).toBe(
+    'Skipping virtualenv creation, as specified in config file.\n',
+  );
 });
 
 it('can do `snyk test` on a poetry project with lockfile', async () => {

--- a/test/image-specific/python-3-poetry.spec.ts
+++ b/test/image-specific/python-3-poetry.spec.ts
@@ -15,7 +15,7 @@ it('can do `snyk test` on a poetry project', async () => {
   expect(stdout).toContain(
     'Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994]',
   );
-  expect(stderr).toBe('');
+  expect(stderr).toBe('Skipping virtualenv creation, as specified in config file.\n');
 });
 
 it('can do `snyk test` on a poetry project with lockfile', async () => {

--- a/test/smoke.spec.ts
+++ b/test/smoke.spec.ts
@@ -7,7 +7,7 @@ describe('smoke tests', () => {
   it('can do `snyk version`', async () => {
     const imageName = process.env.IMAGE_TAG;
     const { stdout, stderr } = await runContainer(imageName, 'snyk version');
-    const versionRegex = /1\.\d\d\d\d\.0 \(standalone\)/;
+    const versionRegex = /1\.\d\d\d\d\.0/;
     expect(stdout).toMatch(versionRegex);
     expect(stderr).toBe('');
   });


### PR DESCRIPTION
- use latest packages provided by packagemanager when building base snyk images
- add golang 1.19 and 1.20
- fix smoke tests / image-specific tests
- remove build of deprecated maven openjdk images

- flag all directories as safe to use for git inside container

git changed its default behaviour and now checks if directories are trusted. This behaviour was breaking the snyk execution on go projects, as `go list` is executed and accessing version control. To establish the previous behaviour, we added a git config to trust directories mapped into the docker container.