### PR TITLE
Fix caching issue and extra layers in images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,5 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     git \
     && apt-get auto-remove -y \
-    && apt-get clean \
+    && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ COPY --from=snyk-alpine ./snyk /usr/local/bin/snyk
 
 FROM parent as linux
 COPY --from=snyk ./snyk /usr/local/bin/snyk
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y ca-certificates git
-RUN apt-get auto-remove -y && apt-get clean -y && rm -rf /var/lib/apt/
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    git \
+    && apt-get auto-remove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
A previous change broke these instructions over multiple RUN statements, which results in extra layers in the final image, and impacts caching. More in the Dockerfile best practices https://docs.docker.com/develop/develop-images/instructions/#apt-get