### PR TITLE
feat: [CLI-1025] optimize base image creation

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -1,0 +1,41 @@
+name: Build Base Images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 1" # Every Monday at 2 AM UTC
+  push:
+    paths:
+      - "Dockerfile.base"
+      - ".github/workflows/base-images.yml"
+
+jobs:
+  build-base-images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        base_type: [ ubuntu, alpine ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: Dockerfile.base
+          target: snyk-base-${{ matrix.base_type }}
+          tags: snyk/snyk:base-${{ matrix.base_type }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            CLI_VERSION=latest

--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -1,13 +1,16 @@
 name: Build Base Images
 
 on:
-  workflow_dispatch:
+  push:
   schedule:
     - cron: "0 2 * * 1" # Every Monday at 2 AM UTC
-  push:
-    paths:
-      - "Dockerfile.base"
-      - ".github/workflows/base-images.yml"
+  workflow_dispatch:
+
+env:
+  # Logically branching out from a global state environment variable
+  # instead of step-wise ($GITHUB_OUTPUT) conditions, to keep the workflow
+  # simple and multiple boolean conditional checks in later steps.
+  SHOULD_BUILD: false
 
 jobs:
   build-base-images:
@@ -17,17 +20,42 @@ jobs:
         base_type: [ ubuntu, alpine ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if built by schedule or manually
+        if: |
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Was triggered by ${{ github.event_name }} - will build"
+          echo "SHOULD_BUILD=true" >> $GITHUB_ENV
+
+      - name: Check if relevant files changed
+        if: env.SHOULD_BUILD != 'true'
+        run: |
+          if git diff --name-only origin/master..HEAD | grep -E "(Dockerfile\.base|\.github/workflows/base-images\.yml)"; then
+            echo "Relevant files changed - will build"
+            echo "SHOULD_BUILD=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          echo "No relevant files changed - skipping build"
+          echo "SHOULD_BUILD=false" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
+        if: env.SHOULD_BUILD == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: env.SHOULD_BUILD == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push base image
+        if: env.SHOULD_BUILD == 'true'
         uses: docker/build-push-action@v6
         with:
           push: true
@@ -37,5 +65,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            CLI_VERSION=latest
+          build-args: CLI_VERSION=latest
+
+      - name: Skip build (no changes)
+        if: env.SHOULD_BUILD == 'false'
+        run: |
+          echo "Skipping build for ${{ matrix.base_type }} - no relevant file changes detected"
+          echo "Workflow completed successfully to allow downstream workflows to trigger"

--- a/.github/workflows/build-and-run-smoke-tests.yml
+++ b/.github/workflows/build-and-run-smoke-tests.yml
@@ -1,18 +1,33 @@
-# +-----------------------------------------------+
-# | WARNING: This file is generated, do not edit! |
-# | Edit _templates/dev.yml.erb instead.          |
-# +-----------------------------------------------+
+# +-----------------------------------------------------------+
+# | WARNING: This file is generated, do not edit!             |
+# | Edit _templates/build-and-run-smoke-tests.yml.erb instead.|
+# +-----------------------------------------------------------+
 
 name: Build and run smoke tests
 
 on:
   workflow_dispatch:
-  push:
+  workflow_run:
+    workflows: [Build Base Images]
+    types: [completed]
     branches-ignore:
     - master
 
 jobs:
+  on-base-images-build-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-base-images-build-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: |
+          echo 'The triggering workflow failed'
+          exit 1
   lint:
+    needs: [on-base-images-build-success]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-and-run-smoke-tests.yml
+++ b/.github/workflows/build-and-run-smoke-tests.yml
@@ -3,7 +3,7 @@
 # | Edit _templates/dev.yml.erb instead.          |
 # +-----------------------------------------------+
 
-name: Dev
+name: Build and run smoke tests
 
 on:
   workflow_dispatch:
@@ -228,6 +228,8 @@ jobs:
         tags: ${{ matrix.tag }}
         file: Dockerfile
         target: ${{ matrix.target }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         build-args: |
           IMAGE=${{ matrix.base }}
           TAG=${{ matrix.tag }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,6 @@
 
 name: Build and push images (preview)
 on:
-  workflow_dispatch:
   push:
     branches:
     - master
@@ -21,14 +20,33 @@ on:
   # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
+  workflow_run:
+    workflows: [Build Base Images]
+    types: [completed]
+  workflow_dispatch:
 
 jobs:
+  on-base-images-build-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-base-images-build-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: |
+          echo 'The triggering workflow failed'
+          exit 1
   build:
     runs-on: ubuntu-latest
+    # Since we want to trigger these builds with specific payload events from the CLI release process
+    # we need to duplicate the conditions from the `on` section.
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'repository_dispatch' && github.event.client_payload.release_channel == 'preview')
     env:
       CLI_VERSION: ${{ github.event.client_payload.version || 'preview' }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -234,7 +234,6 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}-preview
         target: ${{ matrix.target }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,10 +1,11 @@
-# +-----------------------------------------------+
-# | WARNING: This file is generated, do not edit!  |
-# | Edit _templates/release-channel.yml.erb instead.        |
-# +-----------------------------------------------+
+# +-------------------------------------------------+
+# | WARNING: This file is generated, do not edit!   |
+# | Edit _templates/release-channel.yml.erb instead.|
+# +-------------------------------------------------+
 
 name: Build and push images (preview)
 on:
+  workflow_dispatch:
   push:
     branches:
     - master
@@ -14,9 +15,10 @@ on:
     - "!build.rb"
   schedule:
     # As well as running when we make changes we should run at least
-    # every week in order to pick up new parent images and new versions of Snyk
+    # every week in order to pick up new parent images and new versions of Snyk.
     - cron:  "0 0 * * 0"
-  workflow_dispatch:
+  # Manually trigger this through the Github API. Is done when a new version of the CLI is released.
+  # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
 
@@ -234,10 +236,12 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: snyk/snyk:${{ matrix.tag }}-preview
         target: ${{ matrix.target }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         labels: |
           org.opencontainers.image.title=Snyk CLI
           org.opencontainers.image.description=Snyk CLI Docker image

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -234,6 +234,7 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}-preview
         target: ${{ matrix.target }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -234,7 +234,6 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}-rc
         target: ${{ matrix.target }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -234,6 +234,7 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}-rc
         target: ${{ matrix.target }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -5,7 +5,6 @@
 
 name: Build and push images (rc)
 on:
-  workflow_dispatch:
   push:
     branches:
     - master
@@ -21,14 +20,33 @@ on:
   # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
+  workflow_run:
+    workflows: [Build Base Images]
+    types: [completed]
+  workflow_dispatch:
 
 jobs:
+  on-base-images-build-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-base-images-build-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: |
+          echo 'The triggering workflow failed'
+          exit 1
   build:
     runs-on: ubuntu-latest
+    # Since we want to trigger these builds with specific payload events from the CLI release process
+    # we need to duplicate the conditions from the `on` section.
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'repository_dispatch' && github.event.client_payload.release_channel == 'rc')
     env:
       CLI_VERSION: ${{ github.event.client_payload.version || 'rc' }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -1,10 +1,11 @@
-# +-----------------------------------------------+
-# | WARNING: This file is generated, do not edit!  |
-# | Edit _templates/release-channel.yml.erb instead.        |
-# +-----------------------------------------------+
+# +-------------------------------------------------+
+# | WARNING: This file is generated, do not edit!   |
+# | Edit _templates/release-channel.yml.erb instead.|
+# +-------------------------------------------------+
 
 name: Build and push images (rc)
 on:
+  workflow_dispatch:
   push:
     branches:
     - master
@@ -14,9 +15,10 @@ on:
     - "!build.rb"
   schedule:
     # As well as running when we make changes we should run at least
-    # every week in order to pick up new parent images and new versions of Snyk
+    # every week in order to pick up new parent images and new versions of Snyk.
     - cron:  "0 0 * * 0"
-  workflow_dispatch:
+  # Manually trigger this through the Github API. Is done when a new version of the CLI is released.
+  # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
 
@@ -234,10 +236,12 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: snyk/snyk:${{ matrix.tag }}-rc
         target: ${{ matrix.target }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         labels: |
           org.opencontainers.image.title=Snyk CLI
           org.opencontainers.image.description=Snyk CLI Docker image

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -5,7 +5,6 @@
 
 name: Build and push images (stable)
 on:
-  workflow_dispatch:
   push:
     branches:
     - master
@@ -21,14 +20,33 @@ on:
   # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
+  workflow_run:
+    workflows: [Build Base Images]
+    types: [completed]
+  workflow_dispatch:
 
 jobs:
+  on-base-images-build-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-base-images-build-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: |
+          echo 'The triggering workflow failed'
+          exit 1
   build:
     runs-on: ubuntu-latest
+    # Since we want to trigger these builds with specific payload events from the CLI release process
+    # we need to duplicate the conditions from the `on` section.
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'repository_dispatch' && github.event.client_payload.release_channel == 'stable')
     env:
       CLI_VERSION: ${{ github.event.client_payload.version || 'stable' }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -234,6 +234,7 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}
         target: ${{ matrix.target }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -234,7 +234,6 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}
         target: ${{ matrix.target }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,10 +1,11 @@
-# +-----------------------------------------------+
-# | WARNING: This file is generated, do not edit!  |
-# | Edit _templates/release-channel.yml.erb instead.        |
-# +-----------------------------------------------+
+# +-------------------------------------------------+
+# | WARNING: This file is generated, do not edit!   |
+# | Edit _templates/release-channel.yml.erb instead.|
+# +-------------------------------------------------+
 
 name: Build and push images (stable)
 on:
+  workflow_dispatch:
   push:
     branches:
     - master
@@ -14,9 +15,10 @@ on:
     - "!build.rb"
   schedule:
     # As well as running when we make changes we should run at least
-    # every week in order to pick up new parent images and new versions of Snyk
+    # every week in order to pick up new parent images and new versions of Snyk.
     - cron:  "0 0 * * 0"
-  workflow_dispatch:
+  # Manually trigger this through the Github API. Is done when a new version of the CLI is released.
+  # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
 
@@ -234,10 +236,12 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: snyk/snyk:${{ matrix.tag }}
         target: ${{ matrix.target }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         labels: |
           org.opencontainers.image.title=Snyk CLI
           org.opencontainers.image.description=Snyk CLI Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,44 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
 ARG IMAGE
 ARG CLI_VERSION=latest
 
 FROM ${IMAGE} AS parent
 
 ARG TAG
+ARG CLI_VERSION=latest
 
 ENV MAVEN_CONFIG="" \
     SNYK_INTEGRATION_NAME="DOCKER_SNYK" \
     SNYK_INTEGRATION_VERSION=${TAG} \
     SNYK_CFG_DISABLESUGGESTIONS=true \
     SNYK_CLI_VERSION=${CLI_VERSION}
+
 WORKDIR /app
 COPY docker-entrypoint.sh /usr/local/bin/
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["snyk", "test"]
 
-FROM ubuntu AS snyk
-ARG CLI_VERSION
-ENV SNYK_CLI_VERSION=$CLI_VERSION
-RUN echo "SNYK_CLI_VERSION=${SNYK_CLI_VERSION}"
-
-RUN apt-get update && apt-get install -y curl python3 python3-requests
-RUN curl --compressed --output /usr/local/bin/install-snyk.py https://raw.githubusercontent.com/snyk/cli/main/scripts/install-snyk.py
-RUN chmod +x /usr/local/bin/install-snyk.py
-RUN install-snyk.py $SNYK_CLI_VERSION
-
-FROM alpine AS snyk-alpine
-ARG CLI_VERSION
-ENV SNYK_CLI_VERSION=$CLI_VERSION
-RUN echo "SNYK_CLI_VERSION=${SNYK_CLI_VERSION}"
-
-RUN apk update && apk add --no-cache git curl python3 py3-requests
-RUN curl --compressed --output /usr/local/bin/install-snyk.py https://raw.githubusercontent.com/snyk/cli/main/scripts/install-snyk.py
-RUN chmod +x /usr/local/bin/install-snyk.py
-RUN install-snyk.py $SNYK_CLI_VERSION
-
 FROM parent AS alpine
-RUN apk update && apk upgrade --no-cache
-RUN apk add --no-cache libstdc++ git
-COPY --from=snyk-alpine ./snyk /usr/local/bin/snyk
+
+RUN apk update \
+    && apk upgrade --no-cache \
+    && apk add --no-cache \
+    libstdc++ \
+    git \
+    && rm -rf /var/cache/apk/*
+
+COPY --from=snyk/snyk:base-alpine snyk /usr/local/bin/snyk
 
 FROM parent AS linux
-COPY --from=snyk ./snyk /usr/local/bin/snyk
-RUN apt-get update && apt-get install -y \
+
+RUN apt-get update \
+    && apt-get install -y \
     ca-certificates \
     git \
     && apt-get auto-remove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=snyk/snyk:base-ubuntu snyk /usr/local/bin/snyk

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# Base images with pre-installed Snyk CLI and common dependencies
+
+FROM ubuntu:latest AS snyk-base-ubuntu
+ARG CLI_VERSION=latest
+ENV SNYK_CLI_VERSION=$CLI_VERSION
+
+# Install all common dependencies in one layer
+RUN apt-get update \
+    && apt-get install -y \
+    curl \
+    python3 \
+    python3-requests \
+    && apt-get auto-remove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Snyk CLI
+RUN curl --compressed --output /usr/local/bin/install-snyk.py https://raw.githubusercontent.com/snyk/cli/main/scripts/install-snyk.py \
+    && chmod +x /usr/local/bin/install-snyk.py \
+    && install-snyk.py $SNYK_CLI_VERSION
+
+FROM alpine:latest AS snyk-base-alpine
+ARG CLI_VERSION=latest
+ENV SNYK_CLI_VERSION=$CLI_VERSION
+
+# Install all common dependencies in one layer
+RUN apk update \
+    && apk add --no-cache \
+    curl \
+    python3 \
+    py3-requests
+
+# Install Snyk CLI
+RUN curl --compressed --output /usr/local/bin/install-snyk.py https://raw.githubusercontent.com/snyk/cli/main/scripts/install-snyk.py \
+    && chmod +x /usr/local/bin/install-snyk.py \
+    && install-snyk.py $SNYK_CLI_VERSION

--- a/_templates/build-and-run-smoke-tests.yml.erb
+++ b/_templates/build-and-run-smoke-tests.yml.erb
@@ -1,18 +1,33 @@
-# +-----------------------------------------------+
-# | WARNING: This file is generated, do not edit! |
-# | Edit _templates/dev.yml.erb instead.          |
-# +-----------------------------------------------+
+# +-----------------------------------------------------------+
+# | WARNING: This file is generated, do not edit!             |
+# | Edit _templates/build-and-run-smoke-tests.yml.erb instead.|
+# +-----------------------------------------------------------+
 
 name: Build and run smoke tests
 
 on:
   workflow_dispatch:
-  push:
+  workflow_run:
+    workflows: [Build Base Images]
+    types: [completed]
     branches-ignore:
     - master
 
 jobs:
+  on-base-images-build-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-base-images-build-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: |
+          echo 'The triggering workflow failed'
+          exit 1
   lint:
+    needs: [on-base-images-build-success]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/_templates/build-and-run-smoke-tests.yml.erb
+++ b/_templates/build-and-run-smoke-tests.yml.erb
@@ -3,7 +3,7 @@
 # | Edit _templates/dev.yml.erb instead.          |
 # +-----------------------------------------------+
 
-name: Dev
+name: Build and run smoke tests
 
 on:
   workflow_dispatch:

--- a/_templates/dev.yml.erb
+++ b/_templates/dev.yml.erb
@@ -54,6 +54,8 @@ jobs:
         tags: ${{ matrix.tag }}
         file: Dockerfile
         target: ${{ matrix.target }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         build-args: |
           IMAGE=${{ matrix.base }}
           TAG=${{ matrix.tag }}

--- a/_templates/release-channel.yml.erb
+++ b/_templates/release-channel.yml.erb
@@ -5,7 +5,6 @@
 
 name: Build and push images (<%= @release_channel %>)
 on:
-  workflow_dispatch:
   push:
     branches:
     - master
@@ -21,14 +20,33 @@ on:
   # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
+  workflow_run:
+    workflows: [Build Base Images]
+    types: [completed]
+  workflow_dispatch:
 
 jobs:
+  on-base-images-build-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-base-images-build-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: |
+          echo 'The triggering workflow failed'
+          exit 1
   build:
     runs-on: ubuntu-latest
+    # Since we want to trigger these builds with specific payload events from the CLI release process
+    # we need to duplicate the conditions from the `on` section.
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'repository_dispatch' && github.event.client_payload.release_channel == '<%= @release_channel %>')
     env:
       CLI_VERSION: ${{ github.event.client_payload.version || '<%= @release_channel %>' }}

--- a/_templates/release-channel.yml.erb
+++ b/_templates/release-channel.yml.erb
@@ -60,6 +60,7 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}<%= @post_fix %>
         target: ${{ matrix.target }}

--- a/_templates/release-channel.yml.erb
+++ b/_templates/release-channel.yml.erb
@@ -60,10 +60,12 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: snyk/snyk:${{ matrix.tag }}<%= @post_fix %>
         target: ${{ matrix.target }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         labels: |
           org.opencontainers.image.title=Snyk CLI
           org.opencontainers.image.description=Snyk CLI Docker image

--- a/_templates/release-channel.yml.erb
+++ b/_templates/release-channel.yml.erb
@@ -1,10 +1,11 @@
-# +-----------------------------------------------+
-# | WARNING: This file is generated, do not edit!  |
-# | Edit _templates/release-channel.yml.erb instead.        |
-# +-----------------------------------------------+
+# +-------------------------------------------------+
+# | WARNING: This file is generated, do not edit!   |
+# | Edit _templates/release-channel.yml.erb instead.|
+# +-------------------------------------------------+
 
 name: Build and push images (<%= @release_channel %>)
 on:
+  workflow_dispatch:
   push:
     branches:
     - master
@@ -14,9 +15,10 @@ on:
     - "!build.rb"
   schedule:
     # As well as running when we make changes we should run at least
-    # every week in order to pick up new parent images and new versions of Snyk
+    # every week in order to pick up new parent images and new versions of Snyk.
     - cron:  "0 0 * * 0"
-  workflow_dispatch:
+  # Manually trigger this through the Github API. Is done when a new version of the CLI is released.
+  # See more: https://github.com/snyk/cli/blob/cb8c5b44ca3fe05b0e15145eb1fd3cb63c0e56af/release-scripts/upload-artifacts.sh#L124
   repository_dispatch:
     types: [build_and_push_images]
 

--- a/_templates/release-channel.yml.erb
+++ b/_templates/release-channel.yml.erb
@@ -60,7 +60,6 @@ jobs:
       env:
         DOCKER_BUILDKIT: "1"
       with:
-        platforms: linux/amd64,linux/arm64
         push: true
         tags: snyk/snyk:${{ matrix.tag }}<%= @post_fix %>
         target: ${{ matrix.target }}

--- a/build.rb
+++ b/build.rb
@@ -22,10 +22,10 @@ end
 # Everything else is used as explicitly included jobs.
 @seed = @images.shift
 
-# Generate the dev.yml
-templatename = File.join("_templates", "dev.yml.erb")
+# Generate the build-and-run-smoke-tests.yml
+templatename = File.join("_templates", "build-and-run-smoke-tests.yml.erb")
 renderer = ERB.new(File.read(templatename))
-File.open(".github/workflows/dev.yml", "w") { |file| file.puts renderer.result() }
+File.open(".github/workflows/build-and-run-smoke-tests.yml", "w") { |file| file.puts renderer.result() }
 
 # We need to write a file to trigger the image build action, as just changing the
 # contents of workflow doesn't trigger it


### PR DESCRIPTION
Right now every build and test results in about 80x identical `apt` or `apk` runs, resulting in hundreds of requests that inevitably will result in rate limiting or network flakes. Just check any of the tons of logs [here](https://github.com/snyk/snyk-images/actions/runs/16024780632/job/45236811855?pr=135).

This ought to give like a ~95% reduction in package repository calls.

Some other changes have been added as well which is addressed inline as comments.