### PR TITLE
fix: [CLI-883] Adding `elixir` images

### DIFF
--- a/linux
+++ b/linux
@@ -5,7 +5,8 @@ clojure:tools-deps clojure-tools-deps
 elixir
 elixir:1.10 elixir-1.10 DEPRECATED
 elixir:1.11 elixir-1.11 DEPRECATED
-elixir:1.12 elixir-1.12
+elixir:1.12 elixir-1.12 DEPRECATED
+elixir:1.18 elixir-1.18
 golang
 golang:1.12 golang-1.12 DEPRECATED
 golang:1.13 golang-1.13 DEPRECATED


### PR DESCRIPTION
We want to add a [pinned version of Elixir to our Github actions collection](https://github.com/snyk/actions/pull/170), and that should be pinned to a supported version. 

Instead of pinning it to the oldest supported Elixir version, we add a few newer versions, and adding version `1.18` as the pinned version in Actions.